### PR TITLE
Add STM32 CAN overflow diagnostics

### DIFF
--- a/drivers/can/Kconfig.stm32
+++ b/drivers/can/Kconfig.stm32
@@ -33,5 +33,7 @@ config CAN_STM32_PROTECTION_PERIOD_MS
 	depends on CAN_STM32_OVERFLOW_DIAG
 	default 60000
 	help
-	  Protection period in milliseconds to avoid CAN overflow log messages
-	  flooding.
+	  Protection period in milliseconds to avoid CAN overflow log message
+	  flooding: during this period, RX FIFO overflow events are counted
+	  silently, and after the period expires, each overflow is logged and
+	  the protection period restarts.

--- a/drivers/can/Kconfig.stm32
+++ b/drivers/can/Kconfig.stm32
@@ -20,3 +20,18 @@ config CAN_MAX_FILTER
 	help
 	  Defines the array size of the callback/msgq pointers.
 	  Must be at least the size of concurrent reads.
+
+config CAN_STM32_OVERFLOW_DIAG
+	bool "STM32 CAN Overflow Diagnostics"
+	depends on CAN_STM32
+	default n
+	help
+	  Enable RX FIFO overflow diagnostics for STM32 CAN driver.
+
+config CAN_STM32_PROTECTION_PERIOD_MS
+	int "CAN overflow protection period in milliseconds"
+	depends on CAN_STM32_OVERFLOW_DIAG
+	default 60000
+	help
+	  Protection period in milliseconds to avoid CAN overflow log messages
+	  flooding.

--- a/drivers/can/Kconfig.stm32
+++ b/drivers/can/Kconfig.stm32
@@ -26,7 +26,10 @@ config CAN_STM32_OVERFLOW_DIAG
 	depends on CAN_STM32
 	default n
 	help
-	  Enable RX FIFO overflow diagnostics for STM32 CAN driver.
+	  Enable RX FIFO overflow diagnostics for the STM32 CAN driver.
+	  When enabled, the driver records RX FIFO overflow statistics that can
+	  be queried via the can_get_overflow_diag API, and logs overflow events
+	  with rate limiting controlled by CAN_STM32_PROTECTION_PERIOD_MS.
 
 config CAN_STM32_PROTECTION_PERIOD_MS
 	int "CAN overflow protection period in milliseconds"

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -59,28 +59,17 @@ static const uint8_t reg_demand[] = {2, 1, 4, 2};
 /**
  * @brief Handle and record a CAN FIFO overflow event.
  *
- * This helper updates the overflow diagnostics in @p data whenever an
- * overflow is detected on a receive FIFO. It records the timestamp of
- * the first and most recent overflow (`first_timestamp` and
- * `last_timestamp`) and increments the accumulated overflow `count`.
- * All updates to the diagnostic structure are performed under
- * @p data->lock to provide thread-safe access.
+ * Updates overflow diagnostics (count, first/last timestamps) and logs
+ * overflow errors for the specified FIFO. All updates are performed
+ * under @p data->lock for thread-safe access.
  *
- * The overflow reporting is rate-limited by a protection period in
- * milliseconds, defined by PROTECTION_PERIOD_MS. The field
- * `protection_start_time` in @p data->overflow_diag marks the start of
- * this protection window. As long as the time since that start is less
- * than or equal to PROTECTION_PERIOD_MS, the function only updates the
- * diagnostics and does not emit a log message. Once the protection
- * period has elapsed (i.e. when (now - protection_start_time) exceeds
- * PROTECTION_PERIOD_MS), the function logs a single error via
- * LOG_ERR("%s Overflow", fifo_name) to indicate that the specified
- * FIFO has experienced an overflow.
+ * Rate-limiting: Overflow events are silently counted during an initial
+ * protection period (PROTECTION_PERIOD_MS). Once this period expires,
+ * the protection_expired flag is set and all subsequent overflow events
+ * are logged. The protection window never resets.
  *
- * @param data      Pointer to the controller runtime data, which holds
- *                  the overflow diagnostic state.
- * @param fifo_name Name of the affected FIFO, used as a label in the
- *                  error log message.
+ * @param data      Pointer to the controller runtime data.
+ * @param fifo_name Name of the affected FIFO for log messages.
  */
 static inline void handle_overflow(struct can_stm32_data *data, const char *fifo_name)
 {

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -53,6 +53,60 @@ LOG_MODULE_DECLARE(can_driver, CONFIG_CAN_LOG_LEVEL);
 static const uint8_t filter_in_bank[] = {2, 4, 1, 2};
 static const uint8_t reg_demand[] = {2, 1, 4, 2};
 
+#ifdef CONFIG_CAN_STM32_OVERFLOW_DIAG
+#define PROTECTION_PERIOD_MS CONFIG_CAN_STM32_PROTECTION_PERIOD_MS
+
+/**
+ * @brief Handle and record a CAN FIFO overflow event.
+ *
+ * This helper updates the overflow diagnostics in @p data whenever an
+ * overflow is detected on a receive FIFO. It records the timestamp of
+ * the first and most recent overflow (`first_timestamp` and
+ * `last_timestamp`) and increments the accumulated overflow `count`.
+ * All updates to the diagnostic structure are performed under
+ * @p data->lock to provide thread-safe access.
+ *
+ * The overflow reporting is rate-limited by a protection period in
+ * milliseconds, defined by PROTECTION_PERIOD_MS. The field
+ * `protection_start_time` in @p data->overflow_diag marks the start of
+ * this protection window. As long as the time since that start is less
+ * than or equal to PROTECTION_PERIOD_MS, the function only updates the
+ * diagnostics and does not emit a log message. Once the protection
+ * period has elapsed (i.e. when (now - protection_start_time) exceeds
+ * PROTECTION_PERIOD_MS), the function logs a single error via
+ * LOG_ERR("%s Overflow", fifo_name) to indicate that the specified
+ * FIFO has experienced an overflow.
+ *
+ * @param data      Pointer to the controller runtime data, which holds
+ *                  the overflow diagnostic state.
+ * @param fifo_name Name of the affected FIFO, used as a label in the
+ *                  error log message.
+ */
+static inline void handle_overflow(struct can_stm32_data *data, const char *fifo_name)
+{
+	uint32_t now;
+	uint32_t start_time;
+	k_spinlock_key_t key;
+
+	now = k_uptime_get_32();
+
+	key = k_spin_lock(&data->lock);
+
+	if (data->overflow_diag.count == 0) {
+		data->overflow_diag.first_timestamp = now;
+	}
+	data->overflow_diag.last_timestamp = now;
+	data->overflow_diag.count++;
+	start_time = data->overflow_diag.protection_start_time;
+
+	k_spin_unlock(&data->lock, key);
+
+	if ((now - start_time) > PROTECTION_PERIOD_MS) {
+		LOG_ERR("%s Overflow", fifo_name);
+	}
+}
+#endif
+
 static void can_stm32_signal_tx_complete(struct can_mailbox *mb)
 {
 	if (mb->tx_callback) {
@@ -113,7 +167,22 @@ void can_stm32_rx_isr_handler(CAN_TypeDef *can, struct can_stm32_data *data)
 	}
 
 	if (can->RF0R & CAN_RF0R_FOVR0) {
-		LOG_ERR("RX FIFO Overflow");
+#ifdef CONFIG_CAN_STM32_OVERFLOW_DIAG
+		can->RF0R |= CAN_RF0R_FOVR0; /* Clear flag */
+		handle_overflow(data, "RX FIFO0");
+#else
+		LOG_ERR("RX FIFO0 Overflow");
+#endif
+	}
+
+	/* Also check FIFO1 */
+	if (can->RF1R & CAN_RF1R_FOVR1) {
+#ifdef CONFIG_CAN_STM32_OVERFLOW_DIAG
+		can->RF1R |= CAN_RF1R_FOVR1; /* Clear flag */
+		handle_overflow(data, "RX FIFO1");
+#else
+		LOG_ERR("RX FIFO1 Overflow");
+#endif
 	}
 }
 
@@ -412,6 +481,36 @@ int can_stm32_get_core_clock(const struct device *dev, uint32_t *rate)
 	return 0;
 }
 
+#ifdef CONFIG_CAN_STM32_OVERFLOW_DIAG
+static int can_stm32_get_overflow_diag(const struct device *dev, struct can_overflow_diag_info *info)
+{
+	struct can_stm32_data *data = dev->data;
+	uint32_t first, last, start;
+	uint32_t first_offset, last_offset;
+	k_spinlock_key_t key;
+
+	key = k_spin_lock(&data->lock);
+
+	info->count = data->overflow_diag.count;
+	if (data->overflow_diag.count > 0) {
+		first = data->overflow_diag.first_timestamp;
+		last = data->overflow_diag.last_timestamp;
+		start = data->overflow_diag.protection_start_time;
+		first_offset = first - start;
+		last_offset = last - start;
+
+		info->first_timestamp = first_offset;
+		info->last_timestamp = last_offset;
+	} else {
+		info->first_timestamp = 0;
+		info->last_timestamp = 0;
+	}
+
+	k_spin_unlock(&data->lock, key);
+	return 0;
+}
+#endif
+
 static int can_stm32_init(const struct device *dev)
 {
 	const struct can_stm32_config *cfg = DEV_CFG(dev);
@@ -433,6 +532,11 @@ static int can_stm32_init(const struct device *dev)
 	data->mb1.tx_callback = NULL;
 	data->mb2.tx_callback = NULL;
 	data->state_change_isr = NULL;
+
+#ifdef CONFIG_CAN_STM32_OVERFLOW_DIAG
+	memset(&data->lock, 0x00, sizeof(data->lock));
+	data->overflow_diag.protection_start_time = k_uptime_get_32();
+#endif
 
 	data->filter_usage = (1ULL << CAN_MAX_NUMBER_OF_FILTERS) - 1ULL;
 	(void)memset(data->rx_cb, 0, sizeof(data->rx_cb));
@@ -1105,6 +1209,9 @@ static const struct can_driver_api can_api_funcs = {
 	.get_state = can_stm32_get_state,
 #ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
 	.recover = can_stm32_recover,
+#endif
+#ifdef CONFIG_CAN_STM32_OVERFLOW_DIAG
+	.get_overflow_diag = can_stm32_get_overflow_diag,
 #endif
 	.register_state_change_isr = can_stm32_register_state_change_isr,
 	.get_core_clock = can_stm32_get_core_clock,

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -486,22 +486,16 @@ int can_stm32_get_core_clock(const struct device *dev, uint32_t *rate)
 static int can_stm32_get_overflow_diag(const struct device *dev, struct can_overflow_diag_info *info)
 {
 	struct can_stm32_data *data = dev->data;
-	uint32_t first, last, start;
-	uint32_t first_offset, last_offset;
 	k_spinlock_key_t key;
 
 	key = k_spin_lock(&data->lock);
 
 	info->count = data->overflow_diag.count;
 	if (data->overflow_diag.count > 0) {
-		first = data->overflow_diag.first_timestamp;
-		last = data->overflow_diag.last_timestamp;
-		start = data->overflow_diag.protection_start_time;
-		first_offset = first - start;
-		last_offset = last - start;
-
-		info->first_timestamp = first_offset;
-		info->last_timestamp = last_offset;
+		info->first_timestamp = data->overflow_diag.first_timestamp -
+					data->overflow_diag.protection_start_time;
+		info->last_timestamp = data->overflow_diag.last_timestamp -
+					data->overflow_diag.protection_start_time;
 	} else {
 		info->first_timestamp = 0;
 		info->last_timestamp = 0;

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -86,6 +86,7 @@ static inline void handle_overflow(struct can_stm32_data *data, const char *fifo
 {
 	uint32_t now;
 	uint32_t start_time;
+	bool should_log = false;
 	k_spinlock_key_t key;
 
 	now = k_uptime_get_32();
@@ -97,11 +98,22 @@ static inline void handle_overflow(struct can_stm32_data *data, const char *fifo
 	}
 	data->overflow_diag.last_timestamp = now;
 	data->overflow_diag.count++;
-	start_time = data->overflow_diag.protection_start_time;
+
+	/* Check protection period only once on first expiration */
+	if (!data->overflow_diag.protection_expired) {
+		start_time = data->overflow_diag.protection_start_time;
+		if ((now - start_time) > PROTECTION_PERIOD_MS) {
+			data->overflow_diag.protection_expired = true;
+			should_log = true;
+		}
+	} else {
+		/* Protection period already expired, log every occurrence */
+		should_log = true;
+	}
 
 	k_spin_unlock(&data->lock, key);
 
-	if ((now - start_time) > PROTECTION_PERIOD_MS) {
+	if (should_log) {
 		LOG_ERR("%s Overflow", fifo_name);
 	}
 }
@@ -536,6 +548,7 @@ static int can_stm32_init(const struct device *dev)
 #ifdef CONFIG_CAN_STM32_OVERFLOW_DIAG
 	memset(&data->lock, 0x00, sizeof(data->lock));
 	data->overflow_diag.protection_start_time = k_uptime_get_32();
+	data->overflow_diag.protection_expired = false;
 #endif
 
 	data->filter_usage = (1ULL << CAN_MAX_NUMBER_OF_FILTERS) - 1ULL;

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -536,8 +536,8 @@ static int can_stm32_init(const struct device *dev)
 
 #ifdef CONFIG_CAN_STM32_OVERFLOW_DIAG
 	memset(&data->lock, 0x00, sizeof(data->lock));
+	memset(&data->overflow_diag, 0x00, sizeof(data->overflow_diag));
 	data->overflow_diag.protection_start_time = k_uptime_get_32();
-	data->overflow_diag.protection_expired = false;
 #endif
 
 	data->filter_usage = (1ULL << CAN_MAX_NUMBER_OF_FILTERS) - 1ULL;

--- a/drivers/can/can_stm32.h
+++ b/drivers/can/can_stm32.h
@@ -72,6 +72,7 @@ struct can_stm32_data {
 		uint32_t first_timestamp;
 		uint32_t last_timestamp;
 		uint32_t protection_start_time;
+		bool protection_expired;
 	} overflow_diag;
 	struct k_spinlock lock;
 #endif

--- a/drivers/can/can_stm32.h
+++ b/drivers/can/can_stm32.h
@@ -9,6 +9,7 @@
 #define ZEPHYR_DRIVERS_CAN_STM32_CAN_H_
 
 #include <drivers/can.h>
+#include <kernel.h>
 
 #define DEV_DATA(dev) ((struct can_stm32_data *const)(dev)->data)
 #define DEV_CFG(dev) \
@@ -65,6 +66,15 @@ struct can_stm32_data {
 	can_rx_callback_t rx_cb[CONFIG_CAN_MAX_FILTER];
 	void *cb_arg[CONFIG_CAN_MAX_FILTER];
 	can_state_change_isr_t state_change_isr;
+#ifdef CONFIG_CAN_STM32_OVERFLOW_DIAG
+	struct {
+		uint32_t count;
+		uint32_t first_timestamp;
+		uint32_t last_timestamp;
+		uint32_t protection_start_time;
+	} overflow_diag;
+	struct k_spinlock lock;
+#endif
 };
 
 struct can_stm32_config {

--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -356,6 +356,13 @@ typedef enum can_state (*can_get_state_t)(const struct device *dev,
 					  struct can_bus_err_cnt *err_cnt);
 
 #ifdef CONFIG_CAN_STM32_OVERFLOW_DIAG
+/**  
+ * @brief Diagnostic information about CAN receive FIFO overflows.  
+ *  
+ * This structure is used with @ref can_get_overflow_diag_t to report how many  
+ * overflow events have occurred and when they were first and most recently  
+ * observed.  
+ */ 
 struct can_overflow_diag_info {
 	uint32_t count;
 	uint32_t first_timestamp;
@@ -363,7 +370,7 @@ struct can_overflow_diag_info {
 };
 
 typedef int (*can_get_overflow_diag_t)(const struct device *dev,
-                                       struct can_overflow_diag_info *info);
+										struct can_overflow_diag_info *info);
 #endif
 
 typedef void(*can_register_state_change_isr_t)(const struct device *dev,

--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -896,10 +896,10 @@ enum can_state z_impl_can_get_state(const struct device *dev,
  * @retval negative on error.
  */
 __syscall int can_get_overflow_diag(const struct device *dev,
-                                    struct can_overflow_diag_info *info);
+				      struct can_overflow_diag_info *info);
 
 static inline int z_impl_can_get_overflow_diag(const struct device *dev,
-                                               struct can_overflow_diag_info *info)
+					       struct can_overflow_diag_info *info)
 {
 	const struct can_driver_api *api =
 			(const struct can_driver_api *)dev->api;

--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -355,6 +355,17 @@ typedef int (*can_recover_t)(const struct device *dev, k_timeout_t timeout);
 typedef enum can_state (*can_get_state_t)(const struct device *dev,
 					  struct can_bus_err_cnt *err_cnt);
 
+#ifdef CONFIG_CAN_STM32_OVERFLOW_DIAG
+struct can_overflow_diag_info {
+	uint32_t count;
+	uint32_t first_timestamp;
+	uint32_t last_timestamp;
+};
+
+typedef int (*can_get_overflow_diag_t)(const struct device *dev,
+                                       struct can_overflow_diag_info *info);
+#endif
+
 typedef void(*can_register_state_change_isr_t)(const struct device *dev,
 					       can_state_change_isr_t isr);
 
@@ -392,6 +403,9 @@ __subsystem struct can_driver_api {
 	can_recover_t recover;
 #endif
 	can_get_state_t get_state;
+#ifdef CONFIG_CAN_STM32_OVERFLOW_DIAG
+	can_get_overflow_diag_t get_overflow_diag;
+#endif
 	can_register_state_change_isr_t register_state_change_isr;
 	can_get_core_clock_t get_core_clock;
 	/* Min values for the timing registers */
@@ -849,6 +863,35 @@ enum can_state z_impl_can_get_state(const struct device *dev,
 
 	return api->get_state(dev, err_cnt);
 }
+
+#ifdef CONFIG_CAN_STM32_OVERFLOW_DIAG
+/**
+ * @brief Get overflow diagnostics
+ *
+ * Returns the overflow diagnostics of the CAN controller.
+ *
+ * @param dev     Pointer to the device structure for the driver instance.
+ * @param info    Pointer to the destination structure.
+ *
+ * @retval 0 on success.
+ * @retval negative on error.
+ */
+__syscall int can_get_overflow_diag(const struct device *dev,
+                                    struct can_overflow_diag_info *info);
+
+static inline int z_impl_can_get_overflow_diag(const struct device *dev,
+                                               struct can_overflow_diag_info *info)
+{
+	const struct can_driver_api *api =
+			(const struct can_driver_api *)dev->api;
+
+	if (api->get_overflow_diag == NULL) {
+		return -ENOSYS;
+	}
+
+	return api->get_overflow_diag(dev, info);
+}
+#endif
 
 /**
  * @brief Recover from bus-off state

--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -364,8 +364,17 @@ typedef enum can_state (*can_get_state_t)(const struct device *dev,
  * observed.  
  */ 
 struct can_overflow_diag_info {
+	/** Total count of overflow events detected. */
 	uint32_t count;
+	/**
+	 * Milliseconds elapsed from the protection period start to the first
+	 * overflow event (relative timestamp offset from protection_start_time).
+	 */
 	uint32_t first_timestamp;
+	/**
+	 * Milliseconds elapsed from the protection period start to the most
+	 * recent overflow event (relative timestamp offset from protection_start_time).
+	 */
 	uint32_t last_timestamp;
 };
 
@@ -875,7 +884,10 @@ enum can_state z_impl_can_get_state(const struct device *dev,
 /**
  * @brief Get overflow diagnostics
  *
- * Returns the overflow diagnostics of the CAN controller.
+ * Returns the overflow diagnostics of the CAN controller, including the
+ * count of overflow events and their timestamps. The first_timestamp and
+ * last_timestamp fields contain relative timestamps (in milliseconds) offset
+ * from the protection period start time, based on k_uptime_get_32().
  *
  * @param dev     Pointer to the device structure for the driver instance.
  * @param info    Pointer to the destination structure.


### PR DESCRIPTION
Introduce STM32-specific configuration options for CAN overflow diagnostics, implement a public API for diagnostics, and enhance the STM32 driver to track overflow events with rate-limited logging. Document the behavior of the overflow handling function.